### PR TITLE
Enable Link-time optimization

### DIFF
--- a/cmake/modules/LXQtCompilerSettings.cmake
+++ b/cmake/modules/LXQtCompilerSettings.cmake
@@ -119,7 +119,7 @@ endif()
 # Do not allow undefined symbols
 #-----------------------------------------------------------------------------
 if (CMAKE_COMPILER_IS_GNUCXX OR LXQT_COMPILER_IS_CLANGCXX)
-    # -Bsymbolic-functions: replace dynamic symbols used internally in 
+    # -Bsymbolic-functions: replace dynamic symbols used internally in
     #                       shared libs with direct addresses.
     set(SYMBOLIC_FLAGS
         "-Wl,-Bsymbolic-functions -Wl,-Bsymbolic"
@@ -146,7 +146,10 @@ if (CMAKE_COMPILER_IS_GNUCXX OR LXQT_COMPILER_IS_CLANGCXX)
     if (CMAKE_COMPILER_IS_GNUCXX)
         set(LTO_FLAGS "-flto -fuse-linker-plugin")
     elseif (LXQT_COMPILER_IS_CLANGCXX)
-        set(LTO_FLAGS "-flto")
+        # The link-time optimization of clang++/llvm seems to be too aggrassive.
+        # After testing, it breaks the signal/slots of QObject sometimes.
+        # So disable it for now until there is a solution.
+        # set(LTO_FLAGS "-flto")
     endif()
     # apply these options to "Release" build type only
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${LTO_FLAGS}")

--- a/cmake/modules/LXQtCompilerSettings.cmake
+++ b/cmake/modules/LXQtCompilerSettings.cmake
@@ -119,12 +119,21 @@ endif()
 # Do not allow undefined symbols
 #-----------------------------------------------------------------------------
 if (CMAKE_COMPILER_IS_GNUCXX OR LXQT_COMPILER_IS_CLANGCXX)
+    # -Bsymbolic-functions: replace dynamic symbols used internally in 
+    #                       shared libs with direct addresses.
+    set(SYMBOLIC_FLAGS
+        "-Wl,-Bsymbolic-functions -Wl,-Bsymbolic"
+    )
     set(CMAKE_SHARED_LINKER_FLAGS
-        "-Wl,--no-undefined ${CMAKE_SHARED_LINKER_FLAGS}"
+        "-Wl,--no-undefined ${SYMBOLIC_FLAGS} ${CMAKE_SHARED_LINKER_FLAGS}"
     )
     set(CMAKE_MODULE_LINKER_FLAGS
-        "-Wl,--no-undefined ${CMAKE_MODULE_LINKER_FLAGS}"
+        "-Wl,--no-undefined ${SYMBOLIC_FLAGS} ${CMAKE_MODULE_LINKER_FLAGS}"
     )
+    set(CMAKE_EXE_LINKER_FLAGS
+        "${SYMBOLIC_FLAGS} ${CMAKE_EXE_LINKER_FLAGS}"
+    )
+
 endif()
 
 
@@ -134,11 +143,13 @@ endif()
 #-----------------------------------------------------------------------------
 if (CMAKE_COMPILER_IS_GNUCXX OR LXQT_COMPILER_IS_CLANGCXX)
     # -flto: use link-time optimizations to generate more efficient code
-    # -Bsymbolic-functions: replace dynamic symbols used internally in 
-    #                       shared libs with direct addresses.
-    set(LTO_FLAGS "-flto -fuse-linker-plugin")
+    if (CMAKE_COMPILER_IS_GNUCXX)
+        set(LTO_FLAGS "-flto -fuse-linker-plugin")
+    elseif (LXQT_COMPILER_IS_CLANGCXX)
+        set(LTO_FLAGS "-flto")
+    endif()
     # apply these options to "Release" build type only
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${LTO_FLAGS} -Wl,-Bsymbolic-functions")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${LTO_FLAGS}")
 endif()
 
 

--- a/cmake/modules/LXQtCompilerSettings.cmake
+++ b/cmake/modules/LXQtCompilerSettings.cmake
@@ -129,6 +129,20 @@ endif()
 
 
 #-----------------------------------------------------------------------------
+# Turn on more aggrassive optimizations not supported by CMake
+# References: https://wiki.qt.io/Performance_Tip_Startup_Time
+#-----------------------------------------------------------------------------
+if (CMAKE_COMPILER_IS_GNUCXX OR LXQT_COMPILER_IS_CLANGCXX)
+    # -flto: use link-time optimizations to generate more efficient code
+    # -Bsymbolic-functions: replace dynamic symbols used internally in 
+    #                       shared libs with direct addresses.
+    set(LTO_FLAGS "-flto -fuse-linker-plugin")
+    # apply these options to "Release" build type only
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${LTO_FLAGS} -Wl,-Bsymbolic-functions")
+endif()
+
+
+#-----------------------------------------------------------------------------
 # CXX11 and CXX0X requirements
 #-----------------------------------------------------------------------------
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)

--- a/cmake/modules/LXQtCompilerSettings.cmake
+++ b/cmake/modules/LXQtCompilerSettings.cmake
@@ -28,6 +28,13 @@
 #=============================================================================
 
 #-----------------------------------------------------------------------------
+# Build with release mode by default (turn on compiler optimizations)
+#-----------------------------------------------------------------------------
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+#-----------------------------------------------------------------------------
 # Honor visibility properties for all target types.
 #
 # The ``<LANG>_VISIBILITY_PRESET`` and


### PR DESCRIPTION
To generate more efficient code, apply the link-time optimization flags which are not turned on by CMake.
Also avoid dynamic symbol lookup when a exported function is called inside its own library.
References: https://wiki.qt.io/Performance_Tip_Startup_Time

Already tested against the latest LXQt git. All components are built without problems.

@luis-pereira Your review is wanted. Thank you.