### PR TITLE
Enable strict iterators for debug builds

### DIFF
--- a/cmake/modules/LXQtCompilerSettings.cmake
+++ b/cmake/modules/LXQtCompilerSettings.cmake
@@ -75,6 +75,10 @@ add_definitions(
     -DQT_USE_QSTRINGBUILDER
 )
 
+if (CMAKE_BUILD_TYPE MATCHES "Debug")
+  add_definitions(-DQT_STRICT_ITERATORS)
+endif()
+
 
 #-----------------------------------------------------------------------------
 # Detect Clang compiler


### PR DESCRIPTION
Reference: https://wiki.qt.io/Iterators

By default, it sometimes becomes possible to assign non-const iterators to
const-iterators. Thinking of an iterator as a typedef of some pointer type,
C++ allows assignment of a non-const pointer to a const pointer. To
illustrate:

QMap<QString, QString> map;

/* code compiles and works fine but find() returns the non-const
   QMap::iterator that detaches!
*/
QMap<QString, QString>::const_iterator it = map.find("girish");