### PR TITLE
Don't allow Qt foreach/Q_FOREACH

### DIFF
--- a/cmake/modules/LXQtCompilerSettings.cmake
+++ b/cmake/modules/LXQtCompilerSettings.cmake
@@ -73,6 +73,7 @@ include(CheckCXXCompilerFlag)
 #-----------------------------------------------------------------------------
 add_definitions(
     -DQT_USE_QSTRINGBUILDER
+    -DQT_NO_FOREACH
 )
 
 if (CMAKE_BUILD_TYPE MATCHES "Debug")


### PR DESCRIPTION
LXQt code is already foreach-free. Enforcing it at a global level.